### PR TITLE
create special case for not existing 'keyboardLayout Name'

### DIFF
--- a/scripts/get_keyboard_layout.sh
+++ b/scripts/get_keyboard_layout.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+#---
+## Returns stream of selected input sources
+#---
+getInputSrc() {
+  defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources
+} 
+
 {
-  # gets the keyboard layout name
-  defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name" | cut -f 2 -d '=' | tr -d ' ;.\"'
+  # gets the `keyboard layout name`
+  getInputSrc | grep 'KeyboardLayout Name' | cut -f 2 -d '=' | tr -d ' ;.\"'
 } || {
-  # get input mode if there is no keyboard layout name
-  defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | egrep -w 'Input Mode.*inputmethod' | cut -f 2 -d "=" | rev | cut -d'.' -f 1 | rev | tr -d ' ;."'
+  # gets the `input method` if `keyboard layout name` not exists
+  inputMethod=$(getInputSrc | egrep -w 'Input Mode.*inputmethod')
+  echo ${inputMethod#*'inputmethod.'} | cut -f 1 -d "." | tr -d '";'
 }

--- a/scripts/get_keyboard_layout.sh
+++ b/scripts/get_keyboard_layout.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name" | cut -f 2 -d "=" | tr -d ' ;."'
+{
+  # gets the keyboard layout name
+  defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name" | cut -f 2 -d '=' | tr -d ' ;.\"'
+} || {
+  # get input mode if there is no keyboard layout name
+  defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | egrep -w 'Input Mode.*inputmethod' | cut -f 2 -d "=" | rev | cut -d'.' -f 1 | rev | tr -d ' ;."'
+}


### PR DESCRIPTION
#2 When there is no `"KeyboardLayoutName"` in `AppleSelectedInputSource`, get `"Input Method"` instead.